### PR TITLE
fix: Ensure Prisma migrations are included in Docker image

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,12 @@
       "Bash(wt:*)",
       "Bash(/Users/jamespace/Projects/taschengeld/scripts/worktree-manager.sh:*)",
       "Bash(alias wt=\"/Users/jamespace/Projects/taschengeld/scripts/worktree-manager.sh\")",
-      "Bash(./scripts/worktree-manager.sh:*)"
+      "Bash(./scripts/worktree-manager.sh:*)",
+      "Bash(docker run:*)",
+      "Bash(docker pull:*)",
+      "Bash(./scripts/build-multiarch.sh:*)",
+      "Bash(docker buildx build:*)",
+      "Bash(docker build:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -815,6 +815,31 @@ docker inspect groovycodexyz/taschengeld:latest | grep -A 5 "org.opencontainers.
 docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.prod -t test-build .
 ```
 
+### Missing Migrations in Docker Image (FIXED v1.0.11)
+
+**Issue**: Container fails with "No migration found in prisma/migrations" error
+**Root Cause**: Docker COPY command not recursively copying migration subdirectories
+**Solution**: Explicitly copy migrations in Dockerfile.prod (v1.0.11+):
+
+```dockerfile
+# OLD (problematic):
+COPY prisma ./prisma/
+
+# NEW (working):
+COPY prisma/schema.prisma ./prisma/
+COPY prisma/migrations ./prisma/migrations/
+```
+
+**Diagnostic Commands**:
+
+```bash
+# Check if migrations are included in image
+docker run --rm groovycodexyz/taschengeld:latest ls -la /app/prisma/migrations/
+
+# Verify SQL files are present
+docker run --rm groovycodexyz/taschengeld:latest find /app/prisma/migrations -name "*.sql"
+```
+
 ### CI/CD Pipeline Troubleshooting
 
 **GitHub Actions Not Triggering**:

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -17,7 +17,9 @@ RUN apk add --no-cache \
 
 # Copy package files
 COPY package*.json ./
-COPY prisma ./prisma/
+# Copy Prisma schema and migrations explicitly to ensure subdirectories are included
+COPY prisma/schema.prisma ./prisma/
+COPY prisma/migrations ./prisma/migrations/
 
 # Install dependencies and sharp for image optimization
 RUN npm ci && npm install sharp

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -110,8 +110,15 @@ run_migrations() {
     echo "Prisma binary platform: $(ls -la /app/node_modules/.prisma/client/ 2>/dev/null | head -10)"
 
     # Check if migration files exist (excluding lock file)
-    if [ -z "$(ls -A /app/prisma/migrations 2>/dev/null | grep -v migration_lock.toml)" ]; then
-        echo "No migration files found, using schema push approach..."
+    echo "Checking for migration files in /app/prisma/migrations..."
+    migration_count=$(find /app/prisma/migrations -name "*.sql" 2>/dev/null | wc -l)
+    echo "Found $migration_count migration SQL files"
+    
+    if [ "$migration_count" -eq 0 ]; then
+        echo "WARNING: No migration SQL files found in /app/prisma/migrations"
+        echo "Directory contents:"
+        ls -la /app/prisma/migrations/ 2>/dev/null || echo "Migrations directory not found"
+        echo "Using schema push approach as fallback..."
         
         # Try prisma db push as fallback when no migrations exist
         if npx prisma db push --skip-generate 2>&1 | tee /tmp/schema_push.log; then


### PR DESCRIPTION
## Summary
- Fixes "No migration found in prisma/migrations" error when running Docker image
- Ensures compatibility across all platforms (Portainer, Synology, Unraid, etc.)
- Adds better diagnostics for migration-related issues

## Problem
Users downloading the image from Docker Hub were experiencing startup failures with the error:
```
No migration found in prisma/migrations
Error initializing data: error: relation "app_settings" does not exist
```

This was happening because the Docker COPY command wasn't recursively copying the migration subdirectories.

## Solution
1. **Explicitly copy migrations in Dockerfile.prod**:
   - Changed from `COPY prisma ./prisma/` to separate commands
   - Now explicitly copies `schema.prisma` and `migrations` directory
   - Ensures all SQL files are included in the image

2. **Enhanced diagnostics in docker-entrypoint.sh**:
   - Added migration file counting and logging
   - Better error messages when migrations are missing
   - Helps users diagnose issues faster

3. **Updated documentation**:
   - Added troubleshooting section in CLAUDE.md
   - Included diagnostic commands for verification

## Test plan
- [x] Built Docker image locally and verified migrations are included
- [x] Confirmed SQL files are present: `find /app/prisma/migrations -name "*.sql"`
- [x] Tested with fresh database to ensure migrations run properly
- [x] Verified fix doesn't break existing deployments

## Impact
- All users will get working migrations in Docker images
- No breaking changes for existing deployments
- Better error messages help diagnose future issues

🤖 Generated with [Claude Code](https://claude.ai/code)